### PR TITLE
Update from bbatsov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,6 +1672,23 @@ condition](#safe-assignment-in-condition).
   end
   ```
 
+  Prefer `next` in loops instead of conditional blocks.
+
+  ```Ruby
+  # bad
+  [0, 1, 2, 3].each do |item|
+    if item > 1
+      puts item
+    end
+  end
+
+  # good
+  [0, 1, 2, 3].each do |item|
+    next unless item > 1
+    puts item
+  end
+  ```
+
 * <a name="map-find-select-reduce-size"></a>
   Prefer `map` over `collect`, `find` over `detect`, `select` over `find_all`,
   `reduce` over `inject` and `size` over `length`. This is not a hard

--- a/README.md
+++ b/README.md
@@ -1672,10 +1672,10 @@ condition](#safe-assignment-in-condition).
   end
   ```
 
-  Prefer `next` in loops instead of conditional blocks.
+  Prefer `next` in loops instead of conditional blocks. `next` is more clear when conditional expression is complex or we have multiple nested conditional expressions.
 
   ```Ruby
-  # bad
+  # ok
   [0, 1, 2, 3].each do |item|
     if item > 1
       puts item

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Translations of the guide are available in the following languages:
 * [Chinese Simplified](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhCN.md)
 * [Chinese Traditional](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhTW.md)
 * [French](https://github.com/porecreat/ruby-style-guide/blob/master/README-frFR.md)
+* [German](https://github.com/arbox/ruby-style-guide/blob/master/README-deDE.md)
 * [Japanese](https://github.com/fortissimo1997/ruby-style-guide/blob/japanese/README.ja.md)
-* [Korean](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKO.md)
+* [Korean](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKR.md)
 * [Portuguese](https://github.com/rubensmabueno/ruby-style-guide/blob/master/README-PT-BR.md)
 * [Russian](https://github.com/arbox/ruby-style-guide/blob/master/README-ruRU.md)
 * [Spanish](https://github.com/alemohamad/ruby-style-guide/blob/master/README-esLA.md)
@@ -290,7 +291,7 @@ Translations of the guide are available in the following languages:
 
     # good
     1..3
-    'a'..'z'
+    'a'...'z'
     ```
 
 * <a name="indent-when-to-case"></a>
@@ -624,8 +625,8 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="method-parens"></a>
-    Use `def` with parentheses when there are arguments. Omit the
-    parentheses when the method doesn't accept any arguments.
+    Use `def` with parentheses when there are parameters. Omit the
+    parentheses when the method doesn't accept any parameters.
 <sup>[[link](#method-parens)]</sup>
 
    ```Ruby
@@ -640,12 +641,12 @@ Translations of the guide are available in the following languages:
    end
 
    # bad
-   def some_method_with_arguments arg1, arg2
+   def some_method_with_parameters param1, param2
      # body omitted
    end
 
    # good
-   def some_method_with_arguments(arg1, arg2)
+   def some_method_with_parameters(param1, param2)
      # body omitted
    end
    ```
@@ -1671,7 +1672,7 @@ condition](#safe-assignment-in-condition).
   end
   ```
 
-* <a name="map-fine-select-reduce-size"></a>
+* <a name="map-find-select-reduce-size"></a>
   Prefer `map` over `collect`, `find` over `detect`, `select` over `find_all`,
   `reduce` over `inject` and `size` over `length`. This is not a hard
   requirement; if the use of the alias enhances readability, it's ok to use it.
@@ -1679,7 +1680,7 @@ condition](#safe-assignment-in-condition).
   programming languages. The reason the use of `select` is encouraged over
   `find_all` is that it goes together nicely with `reject` and its name is
   pretty self-explanatory.
-<sup>[[link](#map-fine-select-reduce-size)]</sup>
+<sup>[[link](#map-find-select-reduce-size)]</sup>
 
 * <a name="count-vs-size"></a>
   Don't use `count` as a substitute for `size`. For `Enumerable` objects other
@@ -1892,7 +1893,7 @@ condition](#safe-assignment-in-condition).
 <sup>[[link](#reduce-blocks)]</sup>
 
 * <a name="other-arg"></a>
-  When defining binary operators, name the argument `other`(`<<` and `[]` are
+  When defining binary operators, name the parameter `other`(`<<` and `[]` are
   exceptions to the rule, since their semantics are different).
 <sup>[[link](#other-arg)]</sup>
 
@@ -1964,7 +1965,8 @@ condition](#safe-assignment-in-condition).
 
 * <a name="indent-annotations"></a>
   If multiple lines are required to describe the problem, subsequent lines
-  should be indented two spaces after the `#`.
+  should be indented three spaces after the `#` (one general plus two for
+  indentation purpose).
 <sup>[[link](#indent-annotations)]</sup>
 
   ```Ruby
@@ -2261,10 +2263,19 @@ condition](#safe-assignment-in-condition).
   ````
 
 * <a name="no-extend-struct-new"></a>
-  Don't extend a `Struct.new` - it already is a new class. Extending it
-  introduces a superfluous class level and may also introduce weird errors if
-  the file is required multiple times.
+  Don't extend an instance initialized by `Struct.new`. Extending it introduces
+  a superfluous class level and may also introduce weird errors if the file is
+  required multiple times.
 <sup>[[link](#no-extend-struct-new)]</sup>
+
+  ```Ruby
+  # bad
+  class Person < Struct.new(:first_name, :last_name)
+  end
+
+  # good
+  Person = Struct.new(:first_name, :last_name)
+  ````
 
 * <a name="factory-methods"></a>
   Consider adding factory methods to provide additional sensible ways to
@@ -2311,7 +2322,7 @@ condition](#safe-assignment-in-condition).
 <sup>[[link](#visibility)]</sup>
 
 * <a name="indent-public-private-protected"></a>
-  Indent the `public`, `protected`, and `private` methods as much the method
+  Indent the `public`, `protected`, and `private` methods as much as the method
   definitions they apply to. Leave one blank line above the visibility modifier
   and one blank line below in order to emphasize that it applies to all methods
   below it.
@@ -2332,6 +2343,103 @@ condition](#safe-assignment-in-condition).
     def another_private_method
       # ...
     end
+  end
+  ```
+
+* <a name="def-self-singletons"></a>
+  Use `def self.method` to define singleton methods. This makes the code
+  easier to refactor since the class name is not repeated.
+<sup>[[link](#def-self-singletons)]</sup>
+
+  ```Ruby
+  class TestClass
+    # bad
+    def TestClass.some_method
+      # body omitted
+    end
+
+    # good
+    def self.some_other_method
+      # body omitted
+    end
+
+    # Also possible and convenient when you
+    # have to define many singleton methods.
+    class << self
+      def first_method
+        # body omitted
+      end
+
+      def second_method_etc
+        # body omitted
+      end
+    end
+  end
+  ```
+
+* <a name="alias-method-lexically"></a>
+  Prefer `alias` when aliasing methods in lexical class scope as the
+  resolution of `self` in this context is also lexical, and it communicates
+  clearly to the user that the indirection of your alias will not be altered
+  at runtime or by any subclass unless made explicit.
+<sup>[[link](#alias-method-lexically)]</sup>
+
+  ```Ruby
+  class Westerner
+    def first_name
+      @names.first
+    end
+
+    alias given_name first_name
+  end
+  ```
+
+  Since `alias`, like `def`, is a keyword, prefer bareword arguments over
+  symbols or strings. In other words, do `alias foo bar`, not
+  `alias :foo :bar`.
+
+  Also be aware of how Ruby handles aliases and inheritance: an alias
+  references the method that was resolved at the time the alias was defined;
+  it is not dispatched dynamically.
+
+  ```Ruby
+  class Fugitive < Westerner
+    def first_name
+      'Nobody'
+    end
+  end
+  ```
+
+  In this example, `Fugitive#given_name` would still call the original
+  `Westerner#first_name` method, not `Fugitive#first_name`. To override the
+  behavior of `Fugitive#given_name` as well, you'd have to redefine it in the
+  derived class.
+
+  ```Ruby
+  class Fugitive < Westerner
+    def first_name
+      'Nobody'
+    end
+
+    alias given_name first_name
+  end
+  ```
+
+* <a name="alias-method"></a>
+  Always use `alias_method` when aliasing methods of modules, classes, or
+  singleton classes at runtime, as the lexical scope of `alias` leads to
+  unpredictability in these cases.
+<sup>[[link](#alias-method)]</sup>
+
+  ```Ruby
+  module Mononymous
+    def self.included(other)
+      other.class_eval { alias_method :full_name, :given_name }
+    end
+  end
+
+  class Sting < Westerner
+    include Mononymous
   end
   ```
 
@@ -2388,11 +2496,9 @@ condition](#safe-assignment-in-condition).
 
   ```Ruby
   def foo
-    begin
-      fail
-    ensure
-      return 'very bad idea'
-    end
+    fail
+  ensure
+    return 'very bad idea'
   end
   ```
 
@@ -2774,7 +2880,7 @@ condition](#safe-assignment-in-condition).
   ```Ruby
   # bad
   email = data['email']
-  nickname = data['nickname']
+  username = data['nickname']
 
   # good
   email, username = data.values_at('email', 'nickname')
@@ -2896,6 +3002,23 @@ condition](#safe-assignment-in-condition).
     html << "<p>#{paragraph}</p>"
   end
   ```
+
+* <a name="dont-abuse-gsub"></a>
+  Don't use `String#gsub` in scenarios in which you can use a faster more specialized alternative.
+<sup>[[link](#dont-abuse-gsub)]</sup>
+
+    ```Ruby
+    url = 'http://example.com'
+    str = 'lisp-case-rules'
+
+    # bad
+    url.gsub("http://", "https://")
+    str.gsub("-", "_")
+
+    # good
+    url.sub("http://", "https://")
+    str.tr("-", "_")
+    ```
 
 * <a name="heredocs"></a>
   When using heredocs for multi-line strings keep in mind the fact that they
@@ -3142,11 +3265,11 @@ condition](#safe-assignment-in-condition).
   UNSAFE_STRING_METHODS.each do |unsafe_method|
     if 'String'.respond_to?(unsafe_method)
       class_eval <<-EOT, __FILE__, __LINE__ + 1
-        def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-          to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
+        def #{unsafe_method}(*params, &block)       # def capitalize(*params, &block)
+          to_str.#{unsafe_method}(*params, &block)  #   to_str.capitalize(*params, &block)
         end                                       # end
 
-        def #{unsafe_method}!(*args)              # def capitalize!(*args)
+        def #{unsafe_method}!(*params)              # def capitalize!(*params)
           @dirty = true                           #   @dirty = true
           super                                   #   super
         end                                       # end
@@ -3170,7 +3293,7 @@ condition](#safe-assignment-in-condition).
 
     ```ruby
     # bad
-    def method_missing?(meth, *args, &block)
+    def method_missing?(meth, *params, &block)
       if /^find_by_(?<prop>.*)/ =~ meth
         # ... lots of code to do a find_by
       else
@@ -3179,9 +3302,9 @@ condition](#safe-assignment-in-condition).
     end
 
     # good
-    def method_missing?(meth, *args, &block)
+    def method_missing?(meth, *params, &block)
       if /^find_by_(?<prop>.*)/ =~ meth
-        find_by(prop, *args, &block)
+        find_by(prop, *params, &block)
       else
         super
       end
@@ -3238,10 +3361,6 @@ condition](#safe-assignment-in-condition).
   Foo.bar = 1
   ```
 
-* <a name="alias-method"></a>
-  Avoid `alias` when `alias_method` will do.
-<sup>[[link](#alias-method)]</sup>
-
 * <a name="optionparser"></a>
   Use `OptionParser` for parsing complex command line options and `ruby -s`
   for trivial command line options.
@@ -3255,9 +3374,9 @@ condition](#safe-assignment-in-condition).
   Code in a functional way, avoiding mutation when that makes sense.
 <sup>[[link](#functional-code)]</sup>
 
-* <a name="no-arg-mutations"></a>
-  Do not mutate arguments unless that is the purpose of the method.
-<sup>[[link](#no-arg-mutations)]</sup>
+* <a name="no-param-mutations"></a>
+  Do not mutate parameters unless that is the purpose of the method.
+<sup>[[link](#no-param-mutations)]</sup>
 
 * <a name="three-is-the-number-thou-shalt-count"></a>
   Avoid more than three levels of block nesting.


### PR DESCRIPTION
Hi guys,
I've prepared a pull request with recent changes pushed to the original style guides repository (https://github.com/bbatsov/ruby-style-guide). These changes are mostly cosmetic - renaming 'args' to 'params' for example. However, there are few new things as well. I found most of them rather mild except for the one from [line 1675](https://github.com/u2i/ruby-style-guide/compare/u2i:master...update_from_bbatsov?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R1675) - It seems a bit debatable for me, so I put it in separate commit. 
Please let me know what you think about merging these changes to our guides.
